### PR TITLE
Depend on the latest versions of support libraries

### DIFF
--- a/Courier/ivy.xml
+++ b/Courier/ivy.xml
@@ -13,8 +13,8 @@
       <artifact name="${project.name}-sources" type="source" ext="jar" conf="sources"/>
     </publications>
     <dependencies>
-        <dependency org="com.dstevens" name="TheWheel" rev="1.1.2" conf="default;sources"/>
-        <dependency org="com.dstevens" name="CommonServices" rev="1.0.0" conf="default;sources"/>
+        <dependency org="com.dstevens" name="TheWheel" rev="latest.revision" conf="default;sources"/>
+        <dependency org="com.dstevens" name="CommonServices" rev="latest.revision" conf="default;sources"/>
         <dependency org="org.hibernate" name="hibernate-core" rev="4.3.7.Final" conf="default;sources;javadoc"/>
         <dependency org="org.hibernate" name="hibernate-entitymanager" rev="4.3.7.Final" conf="default;sources;javadoc"/>
         <dependency org="com.sun.mail" name="all" rev="1.5.2" conf="default;sources;javadoc"/>


### PR DESCRIPTION
TheWheel and CommonServices have been updated multiple time but this project still explicitly requires old release despite compatibility. It's causing a build complication to keep them locked in and I don't see any need for it.